### PR TITLE
Use the time package for setting the default format

### DIFF
--- a/fluentd.go
+++ b/fluentd.go
@@ -3,6 +3,7 @@ package log
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -30,7 +31,7 @@ func (f *FluentdFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	timestampFormat := f.TimestampFormat
 	if timestampFormat == "" {
-		timestampFormat = logrus.DefaultTimestampFormat
+		timestampFormat = time.RFC3339
 	}
 
 	data["time"] = entry.Time.Format(timestampFormat)


### PR DESCRIPTION
The const from Logrus was made private some time ago, see https://github.com/sirupsen/logrus/commit/325575f18110626a8fd7f027f899aa8c8f5169c6.