### PR TITLE
Don't include message if empty

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -67,7 +67,9 @@ func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 		}
 	}
 
-	data["message"] = entry.Message
+	if entry.Message != "" {
+		data["message"] = entry.Message
+	}
 
 	if s, ok := f.SeverityMap[entry.Level.String()]; ok {
 		data["severity"] = s

--- a/stackdriver_test.go
+++ b/stackdriver_test.go
@@ -53,6 +53,16 @@ var formatterTests = []struct {
 		},
 	},
 	{
+		name: "With Field, skip empty message",
+		run: func(logger *logrus.Logger) {
+			logger.WithField("foo", "bar").Info()
+		},
+		out: map[string]interface{}{
+			"severity": "INFO",
+			"foo":      "bar",
+		},
+	},
+	{
 		name: "WithField, HTTPRequest and Error",
 		run: func(logger *logrus.Logger) {
 			req, _ := http.NewRequest("GET", "http://foo.bar", nil)


### PR DESCRIPTION
Empty messages show up like this in Stackdriver logging (at least for me):

![Screen Shot 2020-04-07 at 10 50 52 PM](https://user-images.githubusercontent.com/3309802/78745852-98f0fa80-7922-11ea-8c4f-83a4566a2b63.png)

Nicer to just skip them entirely.